### PR TITLE
fix: 진료과 추천에서 추가사항 입력, 사전문진에서 이미지 첨부 시 바로 결과가 반횐되도록 수정

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/DepartmentTemplateService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/DepartmentTemplateService.java
@@ -128,15 +128,26 @@ public class DepartmentTemplateService {
 
     // 추가 정보 저장
     @Transactional
-    public void saveAdditional(Member member, String sessionId, AdditionalRequestDTO requestDTO) {
+    public DepartmentTemplateResposneDTO saveAdditionalAndReturnResult(
+            Member member, String sessionId, boolean hasAdditional, AdditionalRequestDTO requestDTO) {
         DepartmentProcessingState state = getState(member, sessionId);
         validateStateOwnership(state, member);
-        state.setAdditional(requestDTO.getAdditional());
+
+        if (!hasAdditional) {
+            state.setAdditional(null);
+        } else {
+            if (requestDTO == null || requestDTO.getAdditional() == null || requestDTO.getAdditional().trim().isEmpty()) {
+                throw new BadRequestException(ErrorCode.INVALID_PARAMETER, "추가정보를 입력해야 합니다.");
+            }
+            state.setAdditional(requestDTO.getAdditional());
+        }
         saveState(member, sessionId, state);
+
+        return getResult(member, sessionId);
     }
 
+
     // 결과 조회
-    @Transactional
     public DepartmentTemplateResposneDTO getResult(Member member, String sessionId) {
         DepartmentProcessingState state = getState(member, sessionId);
         validateStateOwnership(state, member);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/AITemplateController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/AITemplateController.java
@@ -114,28 +114,36 @@ public class AITemplateController {
     }
 
     // 8. 추가 정보 저장
-    @Operation(summary = "8. 추가 정보 저장", description = "증상에 대한 추가 정보를 저장합니다.")
+    @Operation(summary = "8. 추가 정보 저장",
+               description = "hasAdditional=true면 body에 추가 정보를 입력, false면 추가 정보를 입려하지 않습니다.")
     @PostMapping("/additional")
     public ResponseEntity<Void> saveAdditional(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("sessionId") String sessionId,
-            @RequestBody AdditionalRequestDTO requestDTO) {
+            @RequestParam("hasAdditional") boolean hasAdditional,
+            @RequestBody(required = false) AdditionalRequestDTO requestDTO) {
         Member member = userDetails.getMember();
-        aitemplateService.saveAdditional(member, sessionId, requestDTO);
+        aitemplateService.saveAdditional(member, sessionId, hasAdditional, requestDTO);
         return ResponseEntity.ok().build();
     }
 
+
     // 9. 증상 관련 이미지 업로드
-    @Operation(summary = "9. 증상 관련 이미지 업로드", description = "증상과 관련된 이미지를 저장합니다.")
+    @Operation(summary = "9. 증상 관련 이미지 업로드",
+               description = "hasImages=true면 파일 첨부 필수, false면 파일 없이 결과를 반환합니다.")
     @PostMapping("/images")
-    public ResponseEntity<List<UuidFileResponseDTO>> uploadImages(
+    public ResponseEntity<AITemplateResponseDTO> uploadImages(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("sessionId") String sessionId,
-            @RequestPart List<MultipartFile> files) {
+            @RequestParam("hasImages") boolean hasImages,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files) {
         Member member = userDetails.getMember();
-        List<UuidFileResponseDTO> result = aitemplateService.uploadImages(sessionId, files, member);
+        AITemplateResponseDTO result = aitemplateService.uploadImagesAndReturnResult(
+                sessionId, files, hasImages, member
+        );
         return ResponseEntity.ok(result);
     }
+
 
     // 10. 사전문진 분석/요약 결과 동시 조회
     @Operation(summary = "10. 사전문진 분석/요약 결과 동시 조회", description = "사전문진 분석과 요약 결과를 동시에 조회합니다.")

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DepartmentTemplateController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DepartmentTemplateController.java
@@ -70,26 +70,20 @@ public class DepartmentTemplateController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "5. 추가 정보(문장) 입력", description = "증상에 대한 추가 정보를 저장합니다.")
+    @Operation(summary = "5. 추가 정보 입력",
+               description = "hasAdditional=true면 body에 추가 정보를 입력, false면 입력 없이 결과를 반환합니다.")
     @PostMapping("/additional")
-    public ResponseEntity<Void> saveAdditional(
+    public ResponseEntity<DepartmentTemplateResposneDTO> saveAdditional(
+            @RequestParam("hasAdditional") boolean hasAdditional,
             @RequestParam("sessionId") String sessionId,
             @RequestBody AdditionalRequestDTO requestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
-        departmentTemplateService.saveAdditional(member, sessionId, requestDTO);
-        return ResponseEntity.ok().build();
+        DepartmentTemplateResposneDTO result = departmentTemplateService.saveAdditionalAndReturnResult(
+                member, sessionId, hasAdditional, requestDTO);
+        return ResponseEntity.ok(result);
     }
 
-    @Operation(summary = "6. 진료과 추천 결과 조회", description = "입력한 정보를 바탕으로 진료과 추천 결과를 조회합니다.")
-    @GetMapping("/result")
-    public ResponseEntity<DepartmentTemplateResposneDTO> getResult(
-            @RequestParam("sessionId") String sessionId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Member member = userDetails.getMember();
-        DepartmentTemplateResposneDTO response = departmentTemplateService.getResult(member, sessionId);
-        return ResponseEntity.ok(response);
-    }
 
 //    // 상태 조회 (선택)
 //    @GetMapping("/state")


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔒관련 이슈
- #53 

### 🔑 주요 변경사항
- 진료과 추천의 추가사항 api에서 hasAdditional=true 일 경우 추가사항을 입력받고 결과반환, false일 경우 입력없이 결과 반환
- 사전문진의 추가사항 api에서 hasAdditional=true 일 경우 추가사항을 입력받음, false일 경우 입력없음
- 사전문진의 이미지 api에서 hasImages=true 일 경우 이미지를 첨부받고 결과반환, false일 경우 첨부없이 결과 반환
- 진료과 추천과 사전문진 템플릿에서 getResult로 결과조회 api 삭제
