### PR TITLE
fix: 사전문진 템플릿에서 이미지 저장 로직 수정

### DIFF
--- a/src/main/java/com/mediko/mediko_server/global/s3/UuidFile.java
+++ b/src/main/java/com/mediko/mediko_server/global/s3/UuidFile.java
@@ -35,4 +35,18 @@ public class UuidFile extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "profile_id")
     private Member member;
+
+    // 업데이트 메서드 추가
+    public void updateForResult(AITemplate aiTemplate) {
+        this.aiTemplate = aiTemplate;
+        this.sessionId = null;
+    }
+
+    // 필요하다면 파일 URL 등 다른 필드도 추가적으로 업데이트 가능
+    public void updateFileInfo(String fileUrl, FilePath filePath) {
+        this.fileUrl = fileUrl;
+        this.filePath = filePath;
+    }
+
+
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- 사전문진 템플릿에서 이미지 저장 로직에서 sessionId와 member 정보로 저장한 뒤, 각 파일에 대해 aiTemplate을 할당하고 sessionId는 제거하며 업데이트

