### PR TITLE
fix: 사전문진 요약/분석 response를 동적 Map으로 바꿔서 출력

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/AITemplateResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/AITemplateResponseDTO.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,24 +52,25 @@ public class AITemplateResponseDTO {
     private List<Map<String, String>> fileInfo;
 
     // AI 증상 분석 응답 변환
-    public AITemplateResponseDTO convertToAnalysisResponse() {
-        return AITemplateResponseDTO.builder()
-                .aiTemplateId(this.aiTemplateId)
-                .department(this.department)
-                .departmentDescription(this.departmentDescription)
-                .questionsToDoctor(this.questionsToDoctor)
-                .build();
+    public Map<String, Object> toSummaryMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("ai_id", this.aiTemplateId);
+        map.put("basic_info", this.basicInfo);
+        map.put("health_info", this.healthInfo);
+        map.put("symptom_summary", this.symptomSummary);
+        map.put("image_info", this.fileInfo);
+        // 필요한 필드만 추가
+        return map;
     }
 
-    // AI 증상 요약 응답 변환
-    public AITemplateResponseDTO convertToSummaryResponse() {
-        return AITemplateResponseDTO.builder()
-                .aiTemplateId(this.aiTemplateId)
-                .basicInfo(this.basicInfo)
-                .healthInfo(this.healthInfo)
-                .symptomSummary(this.symptomSummary)
-                .fileInfo(this.fileInfo)
-                .build();
+    // AI 증상 분석 응답 변환
+    public Map<String, Object> toAnalysisMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("ai_id", this.aiTemplateId);
+        map.put("department", this.department);
+        map.put("department_description", this.departmentDescription);
+        map.put("questions_to_doctor", this.questionsToDoctor);
+        return map;
     }
 
     public static AITemplateResponseDTO fromEntity(

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/AITemplateController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/AITemplateController.java
@@ -149,7 +149,7 @@ public class AITemplateController {
     @Operation(summary = "10. 증상 이미지 첨부 및 결과 반환",
                description = "hasImages=true면 part에 이미지를 첨부, false면 이미지를 첨부하지 않고 결과를 반환합니다")
     @PostMapping(value ="/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Map<String, AITemplateResponseDTO>> uploadImages(
+    public ResponseEntity<Map<String, Object>> uploadImages(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("sessionId") String sessionId,
             @RequestParam("hasImages") boolean hasImages,
@@ -158,9 +158,9 @@ public class AITemplateController {
         AITemplateResponseDTO dto = aitemplateService.uploadImagesAndReturnResult(
                 sessionId, files, hasImages, member
         );
-        Map<String, AITemplateResponseDTO> result = Map.of(
-                "summary", dto.convertToSummaryResponse(),
-                "analysis", dto.convertToAnalysisResponse()
+        Map<String, Object> result = Map.of(
+                "summary", dto.toSummaryMap(),
+                "analysis", dto.toAnalysisMap()
         );
         return ResponseEntity.ok(result);
     }
@@ -169,23 +169,23 @@ public class AITemplateController {
     // 11. 사전문진 분석 결과 조회
     @Operation(summary = "11. 사전문진 분석 결과 조회", description = "사전문진 분석 결과를 조회합니다.")
     @GetMapping("/result/analysis")
-    public ResponseEntity<AITemplateResponseDTO> getAnalysisResult(
+    public ResponseEntity<Map<String, Object>> getAnalysisResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("sessionId") String sessionId) {
         Member member = userDetails.getMember();
         AITemplateResponseDTO dto = aitemplateService.getResult(member, sessionId);
-        return ResponseEntity.ok(dto.convertToAnalysisResponse());
+        return ResponseEntity.ok(dto.toAnalysisMap());
     }
 
     // 12. 사전문진 요약 결과 조회
     @Operation(summary = "12. 사전문진 요약 결과 조회", description = "사전문진 요약 결과를 조회합니다.")
     @GetMapping("/result/summary")
-    public ResponseEntity<AITemplateResponseDTO> getSummaryResult(
+    public ResponseEntity<Map<String, Object>> getSummaryResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("sessionId") String sessionId) {
         Member member = userDetails.getMember();
         AITemplateResponseDTO dto = aitemplateService.getResult(member, sessionId);
-        return ResponseEntity.ok(dto.convertToSummaryResponse());
+        return ResponseEntity.ok(dto.toSummaryMap());
     }
 
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- 기존에는 사전문진의 summary/analysis response를 각각 builder로 생성 -> 각 방식에 없는 필드가 null로 포함
- 동적 Map 변환을 통해 실제 존재하는 필드만 응답에 포함되도록 개선

