### PR TITLE
fix: 사전문진 결과에 ai_id가 나오지 않는 문제 해결

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/AITemplateService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/AITemplateService.java
@@ -269,6 +269,7 @@ public class AITemplateService {
                 .toList();
 
         return fastApiResponse.toBuilder()
+                .aiTemplateId(aiTemplate.getId())
                 .basicInfo(aiReportMapper.convertToBasicInfoMap(member, state))
                 .healthInfo(aiReportMapper.convertToHealthInfoMap(member, state))
                 .fileInfo(fileInfoList)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- fastApiResponse.toBuilder()로 반환하는 부분에 aiTemplateId 추가
