### PR TITLE
fix: 언어가 한국어로 자동 설정되는 로직 삭제 및 언어 조회 방식 변경

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
@@ -60,6 +60,8 @@ public class BasicInfoService {
 
         basicInfo.updateLanguage(languageRequestDTO.getLanguage());
 
+        member.changeLanguage(languageRequestDTO.getLanguage());
+
         return LanguageResponseDTO.fromBasicInfo(basicInfo);
     }
 
@@ -71,11 +73,10 @@ public class BasicInfoService {
 
         BasicInfo basicInfo = basicInfoRepository.findByMember(member)
                 .orElseGet(() -> {
-                    // 기본 언어는 한국어로 설정
                     String erPassword = flaskCommunicationService.generate119Password();
                     BasicInfo newBasicInfo = BasicInfo.createBasicInfo(
                             member,
-                            Language.KO,
+                            member.getLanguage(),  // Member의 언어 사용
                             erPassword
                     );
                     return basicInfoRepository.save(newBasicInfo);

--- a/src/main/java/com/mediko/mediko_server/domain/member/application/MemberService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/MemberService.java
@@ -86,7 +86,6 @@ public class MemberService {
             throw new BadRequestException(MISSING_REQUIRED_FIELD, "필수 입력 항목이 누락되었습니다.");
         }
 
-        // 임시 멤버에서 언어 정보 가져오기
         TempMember tempMember = tempMemberRepository.findByIdAndIsUsedFalse(tempMemberId)
                 .orElseThrow(() -> new BadRequestException(INVALID_PARAMETER, "유효하지 않은 임시 멤버 ID입니다."));
         
@@ -97,19 +96,13 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(signUpRequestDTO.getPassword());
 
         Member member = signUpRequestDTO.toEntity(encodedPassword);
+        member.changeLanguage(tempMember.getLanguage());
         Member savedMember = memberRepository.save(member);
 
-        // 임시 멤버를 사용됨으로 표시
         tempMember.markAsUsed();
         tempMemberRepository.save(tempMember);
 
         return UserInfoResponseDTO.fromEntity(savedMember);
-    }
-
-    // 기존 회원가입 메서드 (하위 호환성 유지)
-    @Transactional
-    public UserInfoResponseDTO signUp(SignUpRequestDTO signUpRequestDTO) {
-        return signUp(signUpRequestDTO, null);
     }
 
 

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/Member.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.mediko.mediko_server.domain.member.domain;
 
 import java.util.*;
 
+import com.mediko.mediko_server.domain.member.domain.infoType.Language;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
 import com.mediko.mediko_server.global.s3.UuidFile;
@@ -37,6 +38,10 @@ public class Member extends BaseEntity implements UserDetails {
 
     @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "language", nullable = false)
+    private Language language;
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private BasicInfo basicInfo;
@@ -97,6 +102,13 @@ public class Member extends BaseEntity implements UserDetails {
             throw new BadRequestException(INVALID_PARAMETER, "닉네임은 비어 있을 수 없습니다.");
         }
         this.nickname = nickname;
+    }
+
+    public void changeLanguage(Language language) {
+        if (language == null) {
+            throw new BadRequestException(INVALID_PARAMETER, "언어는 비어 있을 수 없습니다.");
+        }
+        this.language = language;
     }
 
     /**


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔒관련 이슈
- #54 

### 🔑 주요 변경사항
- Member 엔티티에 언어(language) 필드 추가
- 회원가입 시 TempMember의 언어 정보를 Member에 반영


