### PR TITLE
feat: 응급실 추천에서 기본주소값 기준 응답기능 생성

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/ErConverter.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/ErConverter.java
@@ -21,7 +21,6 @@ public class ErConverter {
                 .userLongitude(requestDTO.getUserLongitude())
                 .erLatitude(response.getErLatitude())
                 .erLongitude(response.getErLongitude())
-                .isCondition(requestDTO.getIsCondition())
                 .conditions(requestDTO.getConditions())
                 .travelKm(response.getTravelKm())
                 .travelH(response.getTravelH())

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Er.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Er.java
@@ -47,9 +47,6 @@ public class Er extends BaseEntity {
     @Column(name = "travel_s")
     private Integer travelS;
 
-    @Column(name = "is_condition")
-    private Boolean isCondition;
-
     @Convert(converter = StringListConvert.class)
     private List<String> conditions = new ArrayList<>();
 

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/ErRequestDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/ErRequestDTO.java
@@ -22,8 +22,6 @@ public class ErRequestDTO {
     @JsonProperty("lon")
     private Double userLongitude;
 
-    private Boolean isCondition;
-
     private List<String> conditions;
 
 
@@ -31,7 +29,6 @@ public class ErRequestDTO {
         return Er.builder()
                 .userLatitude(this.userLatitude)
                 .userLongitude(this.userLongitude)
-                .isCondition(this.isCondition)
                 .conditions(conditions)
                 .build();
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔒관련 이슈
- #56  

### 🔑 주요 변경사항
-  응급실 추천 requetDTO에서 위경도 값을 입력하지 않아도 기본 주소값으로 처리되도록 수정
- member 클래스의 address를 geocode로 위경도값으로 변환하여 requestDTO의 lat,lon값에 자동으로 넣음
- isCondition 필드 및 관련 코드 삭제
- conditions는 빈 값 허용, 값이 있으면 Enum 값과 일치하는지 검사
